### PR TITLE
Setup local database instance for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,70 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Kaminel
 
-## Getting Started
+> A web-based engine for creating text adventure games.
 
-First, run the development server:
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- [Node.js](https://nodejs.org/) (v18 or higher)
+- [pnpm](https://pnpm.io/) (v8 or higher)
+- [Docker](https://www.docker.com/) and Docker Compose
+- [Git](https://git-scm.com/)
+
+## Local Development Setup
+
+### 1. Clone the Repository
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+git clone https://github.com/rishirajdhr/kaminel.git
+cd kaminel
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### 2. Install Dependencies
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+pnpm install
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### 3. Environment Configuration
 
-## Learn More
+Create a `.env.development` file in the root directory and add the
+following environment variables:
 
-To learn more about Next.js, take a look at the following resources:
+```env
+DATABASE_URL="postgresql://nalase:protect_omega@localhost:5432/kaminel"
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+### 4. Start the Application
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Run the following command:
 
-## Deploy on Vercel
+```bash
+pnpm run dev
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+This command will:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- Start the PostgreSQL container
+- Push the database schema
+- Seed the database with initial data
+- Start the Next.js development server
+
+The application will be available at [http://localhost:3000](http://localhost:3000).
+
+### Stopping the Database
+
+At the end of the development session, run the following command to stop the
+PostgreSQL container:
+
+```bash
+pnpm run db:stop
+```
+
+### Reseeding the Database
+
+If you need to re-seed the database, run the following command:
+
+```bash
+pnpm run db:seed
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+name: kaminel
+services:
+  db:
+    image: postgres:15
+    container_name: postgres_kaminel_local
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: nalase
+      POSTGRES_PASSWORD: protect_omega
+      POSTGRES_DB: kaminel
+    ports:
+      - "5432:5432"

--- a/db/index.ts
+++ b/db/index.ts
@@ -3,7 +3,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-config({ path: ".env.local" });
+config({ path: ".env.development" });
 
 declare global {
   // eslint-disable-next-line no-var

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
 
-config({ path: ".env.local" });
+config({ path: ".env.development" });
 
 export default defineConfig({
   out: "./drizzle",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "pnpm run db:start && next dev --turbopack",
     "build": "next build",
     "db:seed": "tsx ./db/seed.ts",
+    "db:start": "docker compose up -d && pnpm drizzle-kit push && pnpm run db:seed",
+    "db:stop": "docker compose down",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",


### PR DESCRIPTION
Closes: #16

Use Docker Compose to set up a local PostgreSQL database instance to store data during development workflows. This will stop using Supabase during development, freeing it up to be used in production.